### PR TITLE
Fix base path annotation

### DIFF
--- a/main.go
+++ b/main.go
@@ -7,7 +7,6 @@
 // @license.name   MIT License
 // @license.url    https://mit-license.org/
 // @host           localhost:8080
-// @BasePath       /v1
 // @schemes        http https
 // @accept         json
 // @produce        json


### PR DESCRIPTION
As @SrJui mentioned, the new annotations added one `v1` too many to the router group in the documentation.  

**This results in two `v1` groups:**  
`http://localhost:8080/v1/v1/user/register`  
**Which causes:**
`404 page not found`  
**It should only be one `v1` like this:**  
`http://localhost:8080/v1/user/register`

I think the base path annotation should be removed, as the version may vary depending on the endpoint.