### PR TITLE
Updated createPerformanceEntry.go and performanceUtils.go

### DIFF
--- a/endpoints/performanceManagement/createPerformanceEntry.go
+++ b/endpoints/performanceManagement/createPerformanceEntry.go
@@ -1,7 +1,6 @@
 package performanceManagement
 
 import (
-	//"github.com/LucaSchmitz2003/DatabaseFlow"
 	"github.com/Team-Reissdorf/Backend/authHelper"
 	"github.com/Team-Reissdorf/Backend/databaseUtils"
 	"github.com/Team-Reissdorf/Backend/endpoints"

--- a/endpoints/performanceManagement/createPerformanceEntry.go
+++ b/endpoints/performanceManagement/createPerformanceEntry.go
@@ -1,7 +1,7 @@
 package performanceManagement
 
 import (
-	"github.com/LucaSchmitz2003/DatabaseFlow"
+	//"github.com/LucaSchmitz2003/DatabaseFlow"
 	"github.com/Team-Reissdorf/Backend/authHelper"
 	"github.com/Team-Reissdorf/Backend/databaseUtils"
 	"github.com/Team-Reissdorf/Backend/endpoints"
@@ -123,45 +123,45 @@ func CreatePerformance(c *gin.Context) {
 		return
 	}
 	// Check if the exercise goal exists for the athlete's age
-	exists, err := exerciseGoalExistsForAge(ctx, DatabaseFlow.GetDB(ctx), body.ExerciseId, age, strconv.Itoa(time.Now().Year()))
-	if err != nil {
-		endpoints.Logger.Error(ctx, err)
+	exists, err7 := exerciseGoalExistsForAge(ctx, body.ExerciseId, age, strconv.Itoa(time.Now().Year()))
+	if err7 != nil {
+		endpoints.Logger.Error(ctx, err7)
 		c.AbortWithStatusJSON(http.StatusInternalServerError, endpoints.ErrorResponse{Error: "Failed to check exercise goal"})
 		return
 	}
 	if !exists {
-		err := errors.New("No exercise goal found for the athlete's age")
-		endpoints.Logger.Debug(ctx, err)
-		c.AbortWithStatusJSON(http.StatusNotFound, endpoints.ErrorResponse{Error: err.Error()})
+		err8 := errors.New("No exercise goal found for the athlete's age")
+		endpoints.Logger.Debug(ctx, err8)
+		c.AbortWithStatusJSON(http.StatusNotFound, endpoints.ErrorResponse{Error: "No exercise goal found for the athlete's age"})
 		return
 	}
 
 	// Translate the performance body to a database entry
 	performanceBodies := make([]PerformanceBody, 1)
 	performanceBodies[0] = body
-	performanceEntries, err7 := translatePerformanceBodies(ctx, performanceBodies, age, athlete.Sex)
-	if errors.Is(err7, gorm.ErrRecordNotFound) {
-		err7 = errors.Wrap(err7, "No exercise goals for this athlete found")
-		endpoints.Logger.Debug(ctx, err7)
+	performanceEntries, err9 := translatePerformanceBodies(ctx, performanceBodies, age, athlete.Sex)
+	if errors.Is(err9, gorm.ErrRecordNotFound) {
+		err9 = errors.Wrap(err9, "No exercise goals for this athlete found")
+		endpoints.Logger.Debug(ctx, err9)
 		c.AbortWithStatusJSON(http.StatusNotFound, endpoints.ErrorResponse{Error: "No exercise goals found for this athlete"})
 		return
-	} else if err7 != nil {
-		endpoints.Logger.Error(ctx, err7)
+	} else if err9 != nil {
+		endpoints.Logger.Error(ctx, err9)
 		c.AbortWithStatusJSON(http.StatusInternalServerError, endpoints.ErrorResponse{Error: "Failed to get the goals for this athlete"})
 		return
 	}
 
 	// Create performance entry in the database
-	err8 := createNewPerformances(ctx, performanceEntries)
-	if errors.Is(err8, databaseUtils.ErrForeignKeyViolation) {
-		err8 = errors.Wrap(err8, "Athlete or exercise does not exist")
-		endpoints.Logger.Debug(ctx, err8)
+	err10 := createNewPerformances(ctx, performanceEntries)
+	if errors.Is(err10, databaseUtils.ErrForeignKeyViolation) {
+		err10 = errors.Wrap(err10, "Athlete or exercise does not exist")
+		endpoints.Logger.Debug(ctx, err10)
 		c.AbortWithStatusJSON(http.StatusNotFound, endpoints.ErrorResponse{Error: "Athlete or exercise does not exist"})
 		return
 	}
-	if err8 != nil {
-		err8 = errors.Wrap(err8, "Failed to create the performance entry")
-		endpoints.Logger.Error(ctx, err8)
+	if err10 != nil {
+		err10 = errors.Wrap(err10, "Failed to create the performance entry")
+		endpoints.Logger.Error(ctx, err10)
 		c.AbortWithStatusJSON(http.StatusInternalServerError, endpoints.ErrorResponse{Error: "Failed to create the performance entry"})
 		return
 	}

--- a/endpoints/performanceManagement/editPerformanceEntry.go
+++ b/endpoints/performanceManagement/editPerformanceEntry.go
@@ -152,6 +152,7 @@ func EditPerformanceEntry(c *gin.Context) {
 		Date:       body.Date,
 		ExerciseId: body.ExerciseId,
 		Medal:      medal,
+		Athlete:    *athlete,
 	}
 
 	// Update the performance entry in the database

--- a/endpoints/performanceManagement/performanceUtils.go
+++ b/endpoints/performanceManagement/performanceUtils.go
@@ -247,17 +247,19 @@ func updatePerformanceEntry(ctx context.Context, performanceEntry databaseUtils.
 	// Calculate the age of the athlete
 	birthDate, err3 := formatHelper.FormatDate(performanceEntry.Athlete.BirthDate)
 	if err3 != nil {
+		endpoints.Logger.Debug(ctx, "Date Formatter not working..."+err3.Error())
 		err3 = errors.Wrap(err3, "Failed to parse the birth date")
 		return err3
 	}
 	age, err := athleteManagement.CalculateAge(ctx, birthDate)
 	if err != nil {
+		endpoints.Logger.Debug(ctx, "Age Calculator not working...")
 		err = errors.Wrap(err, "Failed to calculate the age of the athlete")
 		return err
 	}
 
 	// Extract the date from the performance entry
-	performanceDate, err := time.Parse("2006-01-02", birthDate)
+	performanceDate, err := time.Parse("2006-01-02", performanceEntry.Date)
 	if err != nil {
 		err = errors.Wrap(err, "Failed to parse the date")
 		return err

--- a/endpoints/performanceManagement/performanceUtils.go
+++ b/endpoints/performanceManagement/performanceUtils.go
@@ -251,6 +251,7 @@ func updatePerformanceEntry(ctx context.Context, performanceEntry databaseUtils.
 		err3 = errors.Wrap(err3, "Failed to parse the birth date")
 		return err3
 	}
+
 	age, err := athleteManagement.CalculateAge(ctx, birthDate)
 	if err != nil {
 		endpoints.Logger.Debug(ctx, "Age Calculator not working...")
@@ -264,6 +265,7 @@ func updatePerformanceEntry(ctx context.Context, performanceEntry databaseUtils.
 		err = errors.Wrap(err, "Failed to parse the date")
 		return err
 	}
+
 	performanceYear := strconv.Itoa(performanceDate.Year())
 	// Check if the exercise goal exists for the athlete's age
 	exists, err := exerciseGoalExistsForAge(ctx, performanceEntry.ExerciseId, age, performanceYear)


### PR DESCRIPTION
Ensure that only performance entries with an exercise goal for the athelete's age are allowed in the performance creation and edit endpoints finished.

Clsoes #134 